### PR TITLE
Fix status code being ignored in close()

### DIFF
--- a/geventwebsocket/websocket.py
+++ b/geventwebsocket/websocket.py
@@ -364,7 +364,9 @@ class WebSocket(object):
         try:
             message = self._encode_bytes(message)
 
-            self.send_frame(message, opcode=self.OPCODE_CLOSE)
+            self.send_frame(
+                struct.pack('!H%ds' % len(message), code, message),
+                opcode=self.OPCODE_CLOSE)
         except WebSocketError:
             # Failed to write the closing frame but it's ok because we're
             # closing the socket anyway.


### PR DESCRIPTION
The `code` parameter in `close()` was not being used. This reverts the message creation logic within `close()` back to the version that was in 0.9.5.