### PR TITLE
fix gevent-websocket not log to access-log issue

### DIFF
--- a/geventwebsocket/gunicorn/workers.py
+++ b/geventwebsocket/gunicorn/workers.py
@@ -1,6 +1,11 @@
 from geventwebsocket.handler import WebSocketHandler
-from gunicorn.workers.ggevent import GeventPyWSGIWorker
+from gunicorn.workers.ggevent import GeventPyWSGIWorker, PyWSGIHandler
+
+
+# Using gunicorn's PyWSGIHandler one can get working access logs, even when using gevent-websocket
+class _Handler(PyWSGIHandler, WebSocketHandler):
+    pass
 
 
 class GeventWebSocketWorker(GeventPyWSGIWorker):
-    wsgi_handler = WebSocketHandler
+    wsgi_handler = _Handler


### PR DESCRIPTION
Current geventwebsocket doesn't log any access request to access log.
This PR is trying to fix that.