### PR TITLE
Use default access logging

### DIFF
--- a/geventwebsocket/handler.py
+++ b/geventwebsocket/handler.py
@@ -252,7 +252,7 @@ class WebSocketHandler(WSGIHandler):
 
     def log_request(self):
         if '101' not in str(self.status):
-            self.logger.info(self.format_request())
+            super().log_request()
 
     @property
     def active_client(self):


### PR DESCRIPTION
Call the super class access logger instead of approximating it's behavior.  This gives us immediate benefits, such as honoring `accesslog` config values.